### PR TITLE
major: new `Osm_Project` application

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         ],
         "psr-4": {
             "Osm\\Runtime\\": "runtime/",
-            "Osm\\Core\\": "src/"
+            "Osm\\Core\\": "src/",
+            "Osm\\Project\\": "project/"
         }
     },
     "autoload-dev": {

--- a/project/App.php
+++ b/project/App.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Osm\Project;
+
+use Osm\Core\App as BaseApp;
+
+class App extends BaseApp
+{
+    public static bool $load_all = true;
+    public static bool $load_dev_sections = true;
+}

--- a/runtime/Compilation/CompiledApp.php
+++ b/runtime/Compilation/CompiledApp.php
@@ -23,6 +23,7 @@ use Osm\Runtime\Traits\Serializable;
  * @property \stdClass|PackageHint $composer_json
  * @property \stdClass|ComposerLock $composer_lock
  * @property bool $load_dev_sections
+ * @property bool $load_all
  * @property Package[] $unsorted_packages
  * @property Module[] $unsorted_modules
  * @property Module[] $referenced_modules
@@ -74,6 +75,12 @@ class CompiledApp extends Object_
         $class = $this->class_name; /* @var App $class */
 
         return $class::$load_dev_sections;
+    }
+
+    protected function get_load_all(): bool {
+        $class = $this->class_name; /* @var App $class */
+
+        return $class::$load_all;
     }
 
     /** @noinspection PhpUnused */
@@ -141,7 +148,9 @@ class CompiledApp extends Object_
 
     /** @noinspection PhpUnused */
     protected function get_referenced_modules(): array {
-        return $this->unloadUnreferencedModules($this->unsorted_modules);
+        return $this->load_all
+            ? $this->unsorted_modules
+            : $this->unloadUnreferencedModules($this->unsorted_modules);
     }
 
     protected function loadModules(array &$modules, Package $package,

--- a/src/App.php
+++ b/src/App.php
@@ -20,6 +20,7 @@ use Osm\Runtime\Apps;
  */
 class App extends Object_ {
     public static bool $load_dev_sections = false;
+    public static bool $load_all = false;
 
     /** @noinspection PhpUnused */
     protected function get_paths(): Paths {

--- a/tests/test_12_project_introspection.php
+++ b/tests/test_12_project_introspection.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Osm\Core\Tests;
+
+use Osm\Core\Samples\Some\Some;
+use Osm\Project\App;
+use Osm\Core\Samples\Some\ObservableObject;
+use Osm\Runtime\Apps;
+use PHPUnit\Framework\TestCase;
+
+class test_12_project_introspection extends TestCase
+{
+    public function test_class_introspection() {
+        // GIVEN a compiled sample app
+        Apps::compile(App::class);
+
+        // WHEN you introspect classes in the context of `Osm_Project`
+        // application
+        $classNames = [];
+        Apps::run(Apps::create(App::class), function (App $app)
+            use (&$classNames)
+        {
+            $classNames = array_keys($app->classes);
+        });
+
+        // THEN you find classes from any module
+        $this->assertContains(Some::class, $classNames);
+    }
+}


### PR DESCRIPTION
### Problem

A typical Osm Framework-based project contains several applications:

* `Osm_App` is the main application that you eventually host on the Web.
* `My_Samples` is a superset of `Osm_App` used in unit tests. It may contain additional modules that are only used in tests.
* `Osm_Tools` is an auxiliary application used to develop and manage the main application.

Each application has intimate knowledge about its modules and classes.

However, in some cases, it's useful to introspect all modules and classes of the project regardless to which application they belong. It is especially useful in code generation.

### Solution

*It's written in present tense, as if the change is already implemented, on purpose. It makes it easier to update the framework documentation with new features*.

New `Osm_Project` application allows to introspect all modules and classes of
the project regardless to which application they belong. 

Use it as follows:

    use Osm\Project\App;
    ...
    
    $result = [];
    
    Apps::run(Apps::create(App::class), function (App $app) use (&$result) {
        // use $app->modules and $app->classes to introspect 
        // all modules and classes of the projects and its 
        // installed dependencies
        
        // put the introspection data you need into `$result`. Don't reference
        // objects of the `Osm_Project` application, as they'll won't work 
        // outside this closure. Instead, create plain PHP objects and arrays, 
        // and fill them as needed 
    });

**Notice**. This application is for introspection only. Invoking user code in context of this application may produce unexpected results.

